### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2704 -- Fix F# (*) operator being incorrectly detected as multi-line comment

### DIFF
--- a/src/languages/fsharp.js
+++ b/src/languages/fsharp.js
@@ -39,7 +39,7 @@ export default function(hljs) {
         className: 'string',
         begin: '"""', end: '"""'
       },
-      hljs.COMMENT('\\(\\*', '\\*\\)'),
+      hljs.COMMENT('\\(\\*(?!\\))', '\\*\\)'),
       {
         className: 'class',
         beginKeywords: 'type', end: '\\(|=|$', excludeEnd: true,


### PR DESCRIPTION
This PR fixes an issue where the F# multiplication operator `(*)` was being incorrectly detected as the start of a multi-line comment.

Problem:
- In F#, multi-line comments are delimited by `(* ... *)`
- The `(*)` operator was incorrectly being matched as the start of a multi-line comment
- This caused incorrect syntax highlighting for code using the multiplication operator

Changes:
- Modified the multi-line comment pattern in fsharp.js
- Added negative lookahead assertion `(?!\))` after `\(\*` to prevent matching when immediately followed by `)`
- Old pattern: `hljs.COMMENT('\(\*', '\*\)')`
- New pattern: `hljs.COMMENT('\(\*(?!\))', '\*\)')`

This change ensures the syntax highlighter correctly handles:
- Multi-line comments: `(* comment *)`
- Multiplication operator: `Operators.(*)`

Tested with the provided code sample and verified correct syntax highlighting.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
