### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2726 -- Enable proper LaTeX command highlighting inside braces

### DIFF
--- a/src/languages/latex.js
+++ b/src/languages/latex.js
@@ -22,10 +22,18 @@ export default function(hljs) {
           relevance: 0,
           contains: [
             {
-              className: 'string', // because it looks like attributes in HTML tags
+              className: 'bracket',
               variants: [
-                {begin: /\[/, end: /\]/},
-                {begin: /\{/, end: /\}/}
+                {
+                  begin: /\{/,
+                  end: /\}/,
+                  contains: ['self', COMMAND]
+                },
+                {
+                  begin: /\[/,
+                  end: /\]/,
+                  contains: ['self', COMMAND]
+                }
               ]
             },
             {


### PR DESCRIPTION
This PR fixes LaTeX syntax highlighting inside braces by modifying the grammar to properly parse nested commands.

Problem:
- Content inside braces was treated as string literals
- Commands inside braces were not highlighted
- This affected a large portion of typical LaTeX code

Changes:
- Modified COMMAND definition in latex.js
- Changed className from 'string' to 'bracket' for brace content
- Enabled recursive parsing within braces using 'self' and COMMAND modes

Before:
```latex
\newcommand{\eTiX}{\TeX}
```
Only outer braces were highlighted, inner commands were plain text

After:
```latex
\newcommand{\eTiX}{\TeX}
```
All commands are properly highlighted, including those inside braces

Testing:
- Verified with examples from original issue
- Tested with nested command definitions
- Confirmed proper highlighting of math mode content

This change significantly improves the accuracy of LaTeX syntax highlighting by treating brace content as normal LaTeX code that can contain nested commands and expressions.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
