### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2765 -- Fix Handlebars highlighting for block if/else statements

### DIFF
--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -87,7 +87,8 @@ export default function(hljs) {
   };
 
   const HELPER_PARAMETER = hljs.inherit(HELPER_NAME_OR_PATH_EXPRESSION, {
-    keywords: LITERALS
+    keywords: LITERALS,
+    className: 'string' // Add className for consistent value highlighting
   });
 
   const SUB_EXPRESSION = {
@@ -146,7 +147,7 @@ export default function(hljs) {
   };
 
   const SUB_EXPRESSION_CONTENTS = hljs.inherit(HELPER_NAME_OR_PATH_EXPRESSION, {
-    className: 'name',
+    className: 'keyword', // Change from 'name' to 'keyword' for built-ins
     keywords: BUILT_INS,
     starts: hljs.inherit(HELPER_PARAMETERS, {
       end: /\)/,
@@ -159,7 +160,7 @@ export default function(hljs) {
 
   const OPENING_BLOCK_MUSTACHE_CONTENTS = hljs.inherit(HELPER_NAME_OR_PATH_EXPRESSION, {
     keywords: BUILT_INS,
-    className: 'name',
+    className: 'keyword', // Change from 'name' to 'keyword'
     starts: hljs.inherit(HELPER_PARAMETERS, {
       end: /}}/,
     })
@@ -218,6 +219,14 @@ export default function(hljs) {
         begin: /\{\{(?=else\}\})/,
         end: /\}\}/,
         keywords: 'else'
+      },
+      {
+        // else if block statement
+        className: 'template-tag',
+        begin: /\{\{else\s+if/,
+        end: /\}\}/,
+        contains: [OPENING_BLOCK_MUSTACHE_CONTENTS],
+        keywords: 'else if'
       },
       {
         // closing block statement


### PR DESCRIPTION
### Problem
Handlebars templates were rendering block `if` and `else` statements with inconsistent and incorrect syntax highlighting, particularly for nested template expressions.

### Changes
- Added specific handling for 'else if' constructs in Handlebars grammar
- Improved keyword highlighting to better distinguish control keywords from values
- Updated className assignments for consistent value highlighting

### Before/After
Before: Inconsistent highlighting of nested template expressions and keywords
After: Proper distinction between:
- Control keywords (#if, else, /if)
- Template values and nested expressions

### Testing
Verified highlighting behavior with test cases including:
```hbs
{{#if this.userData.isLoaded}}
  {{this.userData.value.userName}}
{{else if this.userData.isError}}
  Whoops, something went wrong!
{{/if}}
```

### Related
- Addresses syntax highlighting inconsistencies reported in ticket [PLAYGROUND-PR-2765]()
- Improves readability of Handlebars/Glimmer templates

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
