### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2811 -- Fix Python decorator comment highlighting

### DIFF
--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -275,7 +275,7 @@ export default function(hljs) {
       },
       {
         className: 'meta',
-        begin: /^[\t ]*@/, end: /$/
+        begin: /^[\t ]*@/, end: /(?=#)|$/
       },
       {
         begin: /\b(print|exec)\(/ // don’t highlight keywords-turned-functions in Python 3


### PR DESCRIPTION
This PR fixes an issue where comments on decorator lines in Python were incorrectly highlighted.

Problem:
- Comments on the same line as a decorator were getting highlighted with `hljs-meta` class
- This resulted in incorrect syntax highlighting for inline comments on decorator lines

Solution:
- Modified the decorator pattern rule end matcher in src/languages/python.js
- Changed from `/$/` to `/(?=#)|$/`
- Now stops 'meta' class highlighting when encountering a comment character

Before:
```python
@pytest.mark.asyncio  # comment was highlighted as meta
```

After:
```python
@pytest.mark.asyncio  # comment is properly highlighted as comment
```

Tested:
- Verified correct highlighting of comments on decorator lines
- Confirmed decorator syntax itself is still properly highlighted
- Checked that regular comments continue to work as expected

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
