### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2932 -- Fixed handling of trailing escaped backslashes in properties files

### DIFF
--- a/src/languages/properties.js
+++ b/src/languages/properties.js
@@ -27,7 +27,8 @@ export default function(hljs) {
             end: /$/,
             relevance: 0,
             contains: [
-              { begin: '\\\\\\n' }
+              { begin: '\\\(?!\\\)\n' },
+              { begin: '\\\\\\$' }
             ]
           }
         };


### PR DESCRIPTION
This PR fixes an issue with the properties language where trailing escaped backslashes were not being handled correctly.

Problem:
- Properties files support multi-line values using '\' to escape newlines
- When a line ends with an escaped backslash (\\), such as in Windows paths, the highlighting was incorrect
- Example: 'folder-path = C:\\some\\path\\'

Changes:
1. Updated the line continuation pattern in DELIM_AND_VALUE.contains:
   - Added negative lookahead '\(?!\)\n' to only match single backslashes followed by newlines
   - This prevents matching escaped backslashes as line continuations

2. Added pattern for escaped backslashes:
   - New pattern '\\$' to properly highlight escaped backslashes at end of lines
   - This ensures Windows paths and similar patterns are highlighted correctly

Test case:
```properties
a = a1\
    a2
b = b\\
c = c
```

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
