### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2958 -- Support single-letter XML namespace prefixes

### DIFF
--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -10,7 +10,7 @@ import * as regex from '../lib/regex.js';
 /** @type LanguageFn */
 export default function(hljs) {
   // Element names can contain letters, digits, hyphens, underscores, and periods
-  const TAG_NAME_RE = regex.concat(/[A-Z_]/, regex.optional(/[A-Z0-9_.-]+:/), /[A-Z0-9_.-]*/);
+  const TAG_NAME_RE = regex.concat(/[A-Z_]/, regex.optional(/[A-Z0-9_.-]*:/), /[A-Z0-9_.-]*/);
   const XML_IDENT_RE = /[A-Za-z0-9._:-]+/;
   const XML_ENTITIES = {
     className: 'symbol',


### PR DESCRIPTION
This PR fixes an issue where XML tags with single-letter namespace prefixes were not being highlighted correctly since version 10.4.0.

Changes:
- Modified the TAG_NAME_RE regular expression pattern in xml.js
- Changed namespace prefix quantifier from '+' to '*' to support single-letter prefixes

Before this fix:
```xml
<abc:OK xmlns:abc="..." /> <!-- Highlighted correctly -->
<ab:OK xmlns:ab="..." />  <!-- Highlighted correctly -->
<a:OK xmlns:a="..." />    <!-- Not highlighted correctly -->
```

After this fix:
```xml
<abc:OK xmlns:abc="..." /> <!-- Highlighted correctly -->
<ab:OK xmlns:ab="..." />  <!-- Highlighted correctly -->
<a:OK xmlns:a="..." />    <!-- Now highlighted correctly -->
```

This change maintains compatibility with:
- Multi-character namespace prefixes
- Tags without namespaces
- Existing XML syntax highlighting patterns

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
