### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3000 -- PHP arrow functions highlighted correctly without title mode

### DIFF
--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -130,26 +130,55 @@ export default function(hljs) {
       },
       {
         className: 'function',
-        relevance: 0,
-        beginKeywords: 'fn function', end: /[;{]/, excludeEnd: true,
-        illegal: '[$%\\[]',
-        contains: [
-          hljs.UNDERSCORE_TITLE_MODE,
+        variants: [
           {
-            begin: '=>' // No markup, just a relevance booster
+            // Regular function variant
+            beginKeywords: 'function',
+            end: /[;{]/,
+            excludeEnd: true,
+            illegal: '[$%\\[]',
+            contains: [
+              hljs.UNDERSCORE_TITLE_MODE,
+              {
+                className: 'params',
+                begin: '\\(', end: '\\)',
+                excludeBegin: true,
+                excludeEnd: true,
+                keywords: KEYWORDS,
+                contains: [
+                  'self',
+                  VARIABLE,
+                  hljs.C_BLOCK_COMMENT_MODE,
+                  STRING,
+                  NUMBER
+                ]
+              }
+            ]
           },
           {
-            className: 'params',
-            begin: '\\(', end: '\\)',
-            excludeBegin: true,
+            // Arrow function variant
+            beginKeywords: 'fn',
+            end: /[;{]/,
             excludeEnd: true,
-            keywords: KEYWORDS,
+            illegal: '[$%\\[]',
             contains: [
-              'self',
-              VARIABLE,
-              hljs.C_BLOCK_COMMENT_MODE,
-              STRING,
-              NUMBER
+              {
+                begin: '=>'
+              },
+              {
+                className: 'params',
+                begin: '\\(', end: '\\)',
+                excludeBegin: true,
+                excludeEnd: true,
+                keywords: KEYWORDS,
+                contains: [
+                  'self',
+                  VARIABLE,
+                  hljs.C_BLOCK_COMMENT_MODE,
+                  STRING,
+                  NUMBER
+                ]
+              }
             ]
           }
         ]


### PR DESCRIPTION
Fixed issue where PHP arrow functions were incorrectly treated as having titles, causing wrong syntax highlighting.

Changes:
- Split function definition rule into variants for regular and arrow functions
- Regular functions continue to use title mode highlighting
- Arrow functions now correctly highlighted without title mode

Before:
- Comments in arrow functions incorrectly highlighted as titles
- Incorrect orange highlighting for comments

After:
- Arrow function syntax correctly recognized
- Comments properly highlighted as comments
- Better distinction between regular and arrow function syntax

Testcase:
```php
$fn1 = fn($x) => $x + $y;
```

Additional context:
This fix improves syntax highlighting for PHP arrow functions while maintaining correct highlighting for regular function definitions. The change particularly helps with code readability in modern PHP codebases that make heavy use of arrow functions.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
