### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2704 -- Fix F# `(*)` operator incorrectly detected as multi-line comment

### DIFF
--- a/src/languages/fsharp.js
+++ b/src/languages/fsharp.js
@@ -39,7 +39,7 @@ export default function(hljs) {
         className: 'string',
         begin: '"""', end: '"""'
       },
-      hljs.COMMENT('\\(\\*', '\\*\\)'),
+      hljs.COMMENT('\\(\\*(?!\\))', '\\*\\)'),
       {
         className: 'class',
         beginKeywords: 'type', end: '\\(|=|$', excludeEnd: true,


### PR DESCRIPTION
# Problem
The F# `(*)` operator was incorrectly being detected as the start of a multi-line comment.

F# uses `(* ... *)` syntax for multi-line comments, but `(*)` is also a valid operator name.

# Solution
Modified the multi-line comment pattern to prevent matching `(*)` operator while still correctly handling actual multi-line comments:

- Changed: `hljs.COMMENT('\(\*', '\*\)')`
- To: `hljs.COMMENT('\(\*(?!\))', '\*\)')`

The negative lookahead `(?!\))` ensures we don't match when the `*` is immediately followed by `)`, which is the case for the `(*)` operator.

# Testing
- Verified original example code now correctly highlights the `(*)` operator
- Confirmed multi-line comments using `(* ... *)` are still properly detected

# Related Issues
- Fixes [PLAYGROUND-PR-2704]()

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
