### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2726 -- Fixed LaTeX brace content highlighting

### DIFF
--- a/src/languages/latex.js
+++ b/src/languages/latex.js
@@ -22,10 +22,19 @@ export default function(hljs) {
           relevance: 0,
           contains: [
             {
-              className: 'string', // because it looks like attributes in HTML tags
+              className: 'bracket',
+              relevance: 0,
               variants: [
-                {begin: /\[/, end: /\]/},
-                {begin: /\{/, end: /\}/}
+                {
+                  begin: /\[/,
+                  end: /\]/,
+                  contains: ['self', COMMAND]
+                },
+                {
+                  begin: /\{/,
+                  end: /\}/,
+                  contains: ['self', COMMAND]
+                }
               ]
             },
             {


### PR DESCRIPTION
This PR fixes an issue where content inside braces in LaTeX code was incorrectly treated as string literals, preventing proper syntax highlighting.

Key Changes:
- Modified the COMMAND definition in latex.js to handle brace content correctly
- Changed className to 'bracket' for proper semantic meaning
- Added recursive parsing with 'contains: ['self', COMMAND]' to support nested structures

Before:
- Content inside braces was treated as plain text
- LaTeX commands like \TeX or \! were not highlighted inside braces
- Inconsistent highlighting behavior for nested structures

After:
- Proper highlighting of commands and other LaTeX syntax inside braces
- Consistent parsing of nested structures
- Maintains correct syntax highlighting depth

Tested:
- Verified with provided example code from the ticket
- Checked nested command structures
- Validated complex mathematical expressions

This change significantly improves the readability of LaTeX code by ensuring consistent syntax highlighting throughout the document, including within braced expressions.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
