### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2765 -- Improved Handlebars highlighting for block 'if' and 'else' statements

### DIFF
--- a/src/languages/handlebars.js
+++ b/src/languages/handlebars.js
@@ -87,7 +87,12 @@ export default function(hljs) {
   };
 
   const HELPER_PARAMETER = hljs.inherit(HELPER_NAME_OR_PATH_EXPRESSION, {
-    keywords: LITERALS
+    keywords: LITERALS,
+    className: 'variable',
+    contains: [{
+      begin: /\./,
+      className: 'operator'
+    }]
   });
 
   const SUB_EXPRESSION = {
@@ -173,8 +178,12 @@ export default function(hljs) {
   const BASIC_MUSTACHE_CONTENTS = hljs.inherit(HELPER_NAME_OR_PATH_EXPRESSION, {
     className: 'name',
     keywords: BUILT_INS,
+    contains: [{
+      begin: /\./,
+      className: 'operator'
+    }],
     starts: hljs.inherit(HELPER_PARAMETERS, {
-      end: /}}/,
+      end: /}}/
     })
   });
 
@@ -218,6 +227,12 @@ export default function(hljs) {
         begin: /\{\{(?=else\}\})/,
         end: /\}\}/,
         keywords: 'else'
+      },
+      {
+        className: 'template-tag',
+        begin: /\{\{else\s+if/,
+        end: /\}\}/,
+        contains: [OPENING_BLOCK_MUSTACHE_CONTENTS]
       },
       {
         // closing block statement


### PR DESCRIPTION
This PR fixes the syntax highlighting issues with Handlebars templates, particularly for block `if` and `else` statements.

## Changes

1. Enhanced path handling in HELPER_PARAMETER:
   - Added operator class for dots
   - Added variable class for proper highlighting
   - Ensures consistent highlighting of nested paths

2. Updated BASIC_MUSTACHE_CONTENTS:
   - Improved path handling consistency
   - Added operator class for dots
   - Better variable recognition

3. Added new template-tag rule for 'else if' statements:
   - Proper block handling
   - Consistent highlighting with other block statements

## Before/After Example

```handlebars
{{#if this.userData.isLoaded}}
  {{this.userData.value.userName}}
{{else if this.userData.isError}}
  Whoops, something went wrong!
{{/if}}
```

Now renders with proper highlighting for:
- Block statements
- Nested paths
- Variables
- Keywords

## Testing

Tested with various Handlebars templates including:
- Simple if/else blocks
- Nested path expressions
- Complex conditional blocks

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
