### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2785 -- Added proper variable highlighting for PHP

### DIFF
--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -12,6 +12,7 @@ Category: common
  * */
 export default function(hljs) {
   var VARIABLE = {
+    className: 'variable',
     begin: '\\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*'
   };
   var PREPROCESSOR = {


### PR DESCRIPTION
This PR fixes the issue with PHP variable highlighting by adding the 'variable' className to the VARIABLE definition.

Changes Made:
- Added className: 'variable' to the PHP variable definition in src/languages/php.js

Impact:
- PHP variables will now be properly highlighted in code snippets
- Improves readability of PHP code
- Matches the expected syntax highlighting behavior

Before:
- PHP variables were not receiving proper syntax highlighting
- Code readability was reduced due to lack of variable highlighting

After:
- Variables are properly highlighted with the 'variable' class
- Improved visual distinction of variables in PHP code snippets

Tested:
- Verified highlighting works on sample PHP code
- Confirmed highlighting matches the expected behavior shown in the issue

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
