### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2811 -- Fix decorator comments highlighting in Python

### DIFF
--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -275,7 +275,7 @@ export default function(hljs) {
       },
       {
         className: 'meta',
-        begin: /^[\t ]*@/, end: /$/
+        begin: /^[\t ]*@/, end: /(?=#)|$/
       },
       {
         begin: /\b(print|exec)\(/ // don’t highlight keywords-turned-functions in Python 3


### PR DESCRIPTION
This PR fixes an issue where comments on decorator lines were incorrectly highlighted in Python code.

Problem:
- Comments on the same line as a decorator were getting the `hljs-meta` class instead of `hljs-comment`
- This caused incorrect syntax highlighting for comments after decorators

Solution:
- Modified the decorator rule's end pattern to stop at comment characters
- Changed `end: /$/` to `end: /(?=#)|$/` in the decorator rule
- This allows existing `hljs.HASH_COMMENT_MODE` to properly highlight comments while maintaining decorator highlighting

Example:
```python
@pytest.mark.asyncio  # This comment is now properly highlighted
async def test_async_for():  # Regular comments still work
```

Tested:
- Verified proper comment highlighting on decorator lines
- Confirmed existing decorator highlighting still works correctly
- Tested against provided test cases

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
