### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2897 -- Fixed empty block comment breaking JavaScript syntax highlighting

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -171,7 +171,16 @@ export default function(hljs) {
     className: "comment",
     variants: [
       JSDOC_COMMENT,
-      hljs.C_BLOCK_COMMENT_MODE,
+      {
+        begin: /\/\*/,
+        end: /\*\//,
+        contains: [
+          {
+            className: 'doctag',
+            begin: '@[A-Za-z]+'
+          }
+        ]
+      },
       hljs.C_LINE_COMMENT_MODE
     ]
   };


### PR DESCRIPTION
# Issue
Empty JavaScript block comments (`/**/`) were breaking syntax highlighting for subsequent code.

# Changes
- Modified the COMMENT constant definition in `src/languages/javascript.js`
- Replaced `hljs.C_BLOCK_COMMENT_MODE` with custom block comment implementation
- New implementation uses explicit begin/end patterns (`/\*` and `\*/`)
- Maintains support for JSDoc tags within comments

# Testing
Tested with sample code:
```js
/**/console.log("Hello, World!")/**/
```

Verified that:
1. Empty block comments are properly highlighted
2. Subsequent code maintains correct syntax highlighting
3. JSDoc comments continue to work as expected

# Benefits
- Fixes edge case with empty block comments
- Maintains compatibility with existing JavaScript/TypeScript code
- No regression in JSDoc documentation support

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
