### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3000 -- PHP Arrow Functions Highlighting Fix

### DIFF
--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -131,12 +131,38 @@ export default function(hljs) {
       {
         className: 'function',
         relevance: 0,
-        beginKeywords: 'fn function', end: /[;{]/, excludeEnd: true,
+        beginKeywords: 'function',
+        end: /[;{]/,
+        excludeEnd: true,
         illegal: '[$%\\[]',
         contains: [
           hljs.UNDERSCORE_TITLE_MODE,
           {
-            begin: '=>' // No markup, just a relevance booster
+            className: 'params',
+            begin: '\\(', end: '\\)',
+            excludeBegin: true,
+            excludeEnd: true,
+            keywords: KEYWORDS,
+            contains: [
+              'self',
+              VARIABLE,
+              hljs.C_BLOCK_COMMENT_MODE,
+              STRING,
+              NUMBER
+            ]
+          }
+        ]
+      },
+      {
+        className: 'function',
+        relevance: 0,
+        beginKeywords: 'fn',
+        end: /[;{]/,
+        excludeEnd: true,
+        illegal: '[$%\\[]',
+        contains: [
+          {
+            begin: '=>'
           },
           {
             className: 'params',


### PR DESCRIPTION
This PR fixes the incorrect highlighting of PHP arrow functions without {} blocks.

Problem:
- PHP arrow functions (using `fn`) were being incorrectly highlighted
- Parameters were being treated as function names
- Comments were being incorrectly highlighted as titles

Solution:
1. Split function mode definition into two separate rules:
   - Regular functions: Keep UNDERSCORE_TITLE_MODE, remove 'fn' keyword
   - Arrow functions: New rule without UNDERSCORE_TITLE_MODE, with => marker

Example of fixed highlighting:
```php
$fn1 = fn($x) => $x + $y;
```

Tested with:
- Basic arrow function syntax
- Multi-line arrow functions with comments
- Regular function definitions (ensuring no regression)

Closes [PLAYGROUND-PR-3000]()

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
