### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3018 -- Add BigInt type support for ECMAScript syntax highlighting

### DIFF
--- a/src/languages/lib/ecmascript.js
+++ b/src/languages/lib/ecmascript.js
@@ -82,7 +82,10 @@ const TYPES = [
   "Array",
   "Uint8Array",
   "Uint8ClampedArray",
-  "ArrayBuffer"
+  "ArrayBuffer",
+  "BigInt",
+  "BigInt64Array",
+  "BigUint64Array"
 ];
 
 const ERROR_TYPES = [


### PR DESCRIPTION
Adds syntax highlighting support for BigInt and related types in ECMAScript/JavaScript.

Changes:
- Added 'BigInt' to TYPES array for proper syntax highlighting
- Added 'BigInt64Array' to TYPES array
- Added 'BigUint64Array' to TYPES array

Before:
- BigInt was not highlighted like other built-in types (Number, String, etc.)
- BigInt64Array and BigUint64Array were missing from syntax highlighting

After:
- BigInt is now properly highlighted as a built-in type
- BigInt64Array and BigUint64Array are now properly highlighted

Tested:
- Verified BigInt highlighting matches other built-in types
- Confirmed correct highlighting for BigInt64Array and BigUint64Array

References:
- MDN Web Docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
