### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2958 -- Fixed XML parsing of single-letter namespace prefixes

### DIFF
--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -10,7 +10,12 @@ import * as regex from '../lib/regex.js';
 /** @type LanguageFn */
 export default function(hljs) {
   // Element names can contain letters, digits, hyphens, underscores, and periods
-  const TAG_NAME_RE = regex.concat(/[A-Z_]/, regex.optional(/[A-Z0-9_.-]+:/), /[A-Z0-9_.-]*/);
+  const TAG_NAME_RE = regex.concat(
+    regex.either(
+      regex.concat(/[A-Z_][A-Z0-9_.-]*:/, /[A-Z0-9_.-]+/),
+      /[A-Z_][A-Z0-9_.-]*/
+    )
+  );
   const XML_IDENT_RE = /[A-Za-z0-9._:-]+/;
   const XML_ENTITIES = {
     className: 'symbol',


### PR DESCRIPTION
This PR fixes an issue where single-letter XML namespace prefixes were not being properly highlighted since version 10.4.0.

Changes made:
- Updated TAG_NAME_RE constant in src/languages/xml.js
- Modified regex pattern to handle namespaced and non-namespaced tags separately using regex.either()
- Ensured proper capturing and highlighting of single-letter prefixes (e.g., 'a:', 'b:')

Before this fix:
```xml
<a:FAIL xmlns:a="..." />
```
Was not highlighting correctly.

After this fix:
```xml
<a:OK xmlns:a="..." />
```
Is properly highlighted.

This fixes multiple reported issues:
- Original ticket [PLAYGROUND-PR-2958]()
- Stack Exchange report: meta.stackexchange.com/q/359456/394472
- Stack Overflow example: stackoverflow.com/a/48559689/5846045

Tested with various XML namespace prefix lengths to ensure backwards compatibility.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
