### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3070 -- Standardized language class handling for aliases and full names

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -77,7 +77,7 @@ const HLJS = function(hljs) {
         logger.warn(LANGUAGE_NOT_FOUND.replace("{}", match[1]));
         logger.warn("Falling back to no-highlight mode for this block.", block);
       }
-      return language ? match[1] : 'no-highlight';
+      return language ? language.name : 'no-highlight';
     }
 
     return classes
@@ -657,10 +657,16 @@ const HLJS = function(hljs) {
    * @param {string} [resultLang]
    */
   function updateClassName(element, currentLang, resultLang) {
-    const language = currentLang ? aliases[currentLang] : resultLang;
-
+    const normalizedLang = currentLang ? getLanguage(currentLang)?.name : resultLang;
+    
     element.classList.add("hljs");
-    if (language) element.classList.add(language);
+    if (normalizedLang) {
+      element.classList.add(normalizedLang);
+      // Add the language-prefixed class if it matches the original class
+      if (element.className.includes(`language-${currentLang}`)) {
+        element.classList.add(`language-${normalizedLang}`);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
Standardized how language classes are applied when using both language aliases (e.g., 'language-js') and full names (e.g., 'language-javascript').

## Changes Made
- Modified `blockLanguage` to consistently return the language's canonical name property
- Updated `updateClassName` to handle both alias and full language names uniformly
- Ensured backward compatibility with existing themes that rely on un-prefixed class names

## Problem Solved
Resolved inconsistency where:
- 'language-js' would add both 'language-js' and 'javascript' classes
- 'language-javascript' would not add the 'javascript' class

## Testing
- Verified class name application is consistent across both alias and full language names
- Confirmed existing theme compatibility is maintained
- Tested with various language aliases to ensure proper class application

## Related Issues
Closes #3070
Addresses concerns from #3023

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
