### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3154 -- Added support for quoted heredocs without interpolation in Ruby

### DIFF
--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -124,12 +124,12 @@ export default function(hljs) {
       {
         begin: /\B\?\\?\S/
       },
-      { // heredocs
-        begin: /<<[-~]?'?(\w+)\n(?:[^\n]*\n)*?\s*\1\b/,
+      { // standard heredocs (with interpolation)
+        begin: /<<[-~]?(\w+)\n(?:[^\n]*\n)*?\s*\1\b/,
         returnBegin: true,
         contains: [
           {
-            begin: /<<[-~]?'?/
+            begin: /<<[-~]?/
           },
           hljs.END_SAME_AS_BEGIN({
             begin: /(\w+)/,
@@ -137,6 +137,22 @@ export default function(hljs) {
             contains: [
               hljs.BACKSLASH_ESCAPE,
               SUBST
+            ]
+          })
+        ]
+      },
+      { // quoted heredocs (without interpolation)
+        begin: /<<[-~]?'(\w+)'\n(?:[^\n]*\n)*?\s*\1\b/,
+        returnBegin: true,
+        contains: [
+          {
+            begin: /<<[-~]?'/
+          },
+          hljs.END_SAME_AS_BEGIN({
+            begin: /(\w+)/,
+            end: /(\w+)/,
+            contains: [
+              hljs.BACKSLASH_ESCAPE
             ]
           })
         ]


### PR DESCRIPTION
Fixed an issue where Ruby heredocs without interpolation (`<<-'HEREDOC'`) were not being highlighted correctly.

Changes:
- Split heredoc handling into two variants in STRING.variants array:
  1. Standard heredocs with interpolation (<<-HEREDOC)
  2. Quoted heredocs without interpolation (<<-'HEREDOC')
- Removed SUBST from the contains array for quoted heredocs since they don't support interpolation

Testing:
- Verified that standard heredocs continue to work as expected
- Confirmed proper highlighting for quoted heredocs without interpolation
- Tested with the example code provided in the ticket

Resolves the issue where quoted heredoc endings were not being detected and highlighted properly.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
