### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3207 -- Fix Elixir function capture syntax highlighting

### DIFF
--- a/src/languages/elixir.js
+++ b/src/languages/elixir.js
@@ -212,6 +212,11 @@ export default function(hljs) {
       begin: '(\\$\\W)|((\\$|@@?)(\\w+))'
     },
     {
+      className: 'function',
+      begin: '&' + ELIXIR_IDENT_RE + '/\\d+',
+      relevance: 10
+    },
+    {
       begin: '->'
     },
     { // regexp container
@@ -234,7 +239,7 @@ export default function(hljs) {
           ],
           variants: [
             {
-              begin: '/',
+              begin: '(?<!&)/',
               end: '/[a-z]*'
             },
             {


### PR DESCRIPTION
# Problem
Highlighting of Elixir code was breaking when using function captures (`&function_name/arity`) due to incorrect handling of the forward slash character.

# Changes
- Added new rule in ELIXIR_DEFAULT_CONTAINS array specifically for function captures with high relevance (10)
- Modified regexp to include negative lookbehind `(?<!&)` to prevent matching when preceded by ampersand

# Impact
- Proper syntax highlighting for Elixir function captures (e.g. `&letter?/1`)
- Fixed highlighting of code following function capture syntax
- Maintains correct highlighting for other uses of forward slash

# Testing
Verified fix using provided test case:
```elixir
&letter?/1
```

Confirmed proper highlighting continues through subsequent code.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
