### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3212 -- Fix highlighting of numbers starting with zero in Elixir

### DIFF
--- a/src/languages/elixir.js
+++ b/src/languages/elixir.js
@@ -62,7 +62,7 @@ export default function(hljs) {
   };
   const NUMBER = {
     className: 'number',
-    begin: '(\\b0o[0-7_]+)|(\\b0b[01_]+)|(\\b0x[0-9a-fA-F_]+)|(-?\\b[1-9][0-9_]*(\\.[0-9_]+([eE][-+]?[0-9]+)?)?)',
+    begin: '(\\b0o[0-7_]+)|(\\b0b[01_]+)|(\\b0x[0-9a-fA-F_]+)|(-?\\b[0-9][0-9_]*(\\.[0-9_]+([eE][-+]?[0-9]+)?)?)',
     relevance: 0
   };
   // TODO: could be tightened


### PR DESCRIPTION
This PR fixes how numbers starting with zero are highlighted in Elixir code.

Changes made:
- Modified NUMBER regex pattern in elixir.js from [1-9] to [0-9]
- Now properly highlights:
  - Single zero (0)
  - Decimal integers starting with zero (e.g. 0123)
  - Floating point numbers starting with zero (e.g. 0.3)

Before:
- Only numbers starting with 1-9 were highlighted
- Zero by itself was not highlighted
- For floating point numbers starting with zero, only the decimal part was highlighted

After:
- All valid Elixir numbers are properly highlighted
- Zero is highlighted as a number
- Full floating point numbers starting with zero are highlighted

Related issue: [PLAYGROUND-PR-3212]()

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
