### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3249 -- Make LaTeX magic comment matching case-insensitive

### DIFF
--- a/src/languages/latex.js
+++ b/src/languages/latex.js
@@ -105,7 +105,7 @@ export default function(hljs) {
   };
   const MAGIC_COMMENT = {
     className: 'meta',
-    begin: '% !TeX',
+    begin: /% ![Tt][Ee][Xx]/,
     end: '$',
     relevance: 10
   };


### PR DESCRIPTION
This PR fixes case-sensitivity issues with TeX magic comments in the LaTeX language definition.

Problem:
- Currently only `% !TeX` is matched as a magic comment
- Common variations like `% !TEX` are not highlighted properly
- Most LaTeX editors treat these comments case-insensitively

Solution:
- Modified the MAGIC_COMMENT pattern to use case-insensitive regex
- New pattern `/% ![Tt][Ee][Xx]/` matches both `% !TeX` and `% !TEX`
- Other properties (className, end pattern, relevance) remain unchanged

Example:
```latex
% !TeX program = lualatex   // Was highlighted
% !TEX encoding = UTF-8     // Now also highlighted
```

Tested:
- Verified highlighting works for both case variations
- Confirmed existing magic comment functionality is preserved
- Checked that regular comments are still handled correctly

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
