### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3278 -- Add support for TypeScript generics with extends keyword

### DIFF
--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -74,10 +74,24 @@ export default function(hljs) {
   Object.assign(tsLanguage.keywords, KEYWORDS);
 
   tsLanguage.exports.PARAMS_CONTAINS.push(DECORATOR);
+
+  const GENERIC_TYPE_PARAMETER = {
+    className: 'type-parameter',
+    begin: /</, end: />/,
+    contains: [{
+      className: 'type-parameter-name',
+      begin: IDENT_RE,
+      keywords: {
+        keyword: 'extends'
+      }
+    }]
+  };
+
   tsLanguage.contains = tsLanguage.contains.concat([
     DECORATOR,
     NAMESPACE,
     INTERFACE,
+    GENERIC_TYPE_PARAMETER
   ]);
 
   // TS gets a simpler shebang rule than JS
@@ -86,6 +100,9 @@ export default function(hljs) {
   swapMode(tsLanguage, "use_strict", USE_STRICT);
 
   const functionDeclaration = tsLanguage.contains.find(m => m.label === "func.def");
+  if (functionDeclaration && functionDeclaration.contains) {
+    functionDeclaration.contains.push(GENERIC_TYPE_PARAMETER);
+  }
   functionDeclaration.relevance = 0; // () => {} is more typical in TypeScript
 
   Object.assign(tsLanguage, {


### PR DESCRIPTION
Fixed issue where TypeScript generic types using the `extends` keyword broke syntax highlighting from version 10.3.0 onwards.

### Changes
- Added new GENERIC_TYPE_PARAMETER mode to handle generic type parameters
- Integrated extends keyword support within generic type declarations
- Maintained proper highlighting for generic type constraints

### Technical Details
- Created dedicated mode for generic type parameters
- Enhanced TypeScript grammar to properly handle extends clauses
- Integrated with existing TypeScript language definition
- Preserved compatibility with other TypeScript features

### Example Fixed Code:
```typescript
interface Prefixer<Something extends string> {
  (): `other__${Something}`;
}
```

### Testing
- Verified fix with provided test cases
- Confirmed proper highlighting of extends keyword
- Tested compatibility with existing TypeScript syntax

### Related Issues
- Fixes issue reported in Stack Overflow meta
- Resolves highlighting breaks in VSCode markdown preview

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
