### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3301 -- Fixed CSS inline comments highlighting regression

### DIFF
--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -85,6 +85,7 @@ export default function(hljs) {
           modes.HEXCOLOR,
           modes.IMPORTANT,
           modes.CSS_NUMBER_MODE,
+          hljs.C_BLOCK_COMMENT_MODE,
           ...STRINGS,
           // needed to highlight these as strings and to avoid issues with
           // illegal characters that might be inside urls that would tigger the


### PR DESCRIPTION
Fixed an issue where inline block comments within CSS property values were not being properly highlighted. This was a regression introduced in version 10.6.0.

Changes:
- Added hljs.C_BLOCK_COMMENT_MODE to the contains array in the attribute values section
- This allows for proper highlighting of /* */ style comments within CSS property values

Before:
- Block comments within property values were not properly highlighted
- This affected code using the new `highlightAll` API introduced in 10.6.0

After:
- Block comments are now correctly highlighted in all contexts
- Behavior now matches what was present in version 10.5.0

Tested:
- Verified fix with provided test cases
- Confirmed proper highlighting of inline comments in CSS property values

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
