### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3312 -- Fix switch statement highlighting in C++

### DIFF
--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -412,6 +412,7 @@ export default function(hljs) {
       /(?!if)/,
       /(?!for)/,
       /(?!while)/,
+      /(?!switch)/,
       hljs.IDENT_RE,
       regex.lookahead(/(<[^<>]+>|)\s*\(/))
   };


### PR DESCRIPTION
Fixed incorrect highlighting of 'switch' statement in C++ which was being highlighted as a function.

Problem:
- 'switch' statements were being highlighted differently from other control flow statements (if, while, for)
- This was a regression introduced in version 10.7.0

Solution:
- Modified the FUNCTION_DISPATCH regex pattern in cpp.js
- Added (?!switch) negative lookahead pattern to exclude 'switch' from function highlighting
- This matches the treatment of other control flow statements like if/while/for

Testing:
- Verified correct highlighting of switch statements
- Confirmed no impact on other C++ syntax highlighting
- Behavior now matches version 10.6.0 expectations

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
