### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3287 -- Fix incorrect meta scope handling in Verilog

### DIFF
--- a/src/languages/verilog.js
+++ b/src/languages/verilog.js
@@ -112,17 +112,22 @@ export default function(hljs) {
       },
       {
         className: 'meta',
-        begin: '`',
-        end: '$',
-        keywords: {
-          keyword:
-            'define __FILE__ ' +
-            '__LINE__ begin_keywords celldefine default_nettype define ' +
-            'else elsif end_keywords endcelldefine endif ifdef ifndef ' +
-            'include line nounconnected_drive pragma resetall timescale ' +
-            'unconnected_drive undef undefineall'
-        },
-        relevance: 0
+        variants: [
+          {
+            begin: '`\\s*(define|__FILE__|__LINE__|begin_keywords|celldefine|default_nettype|define|else|elsif|end_keywords|endcelldefine|endif|ifdef|ifndef|include|line|nounconnected_drive|pragma|resetall|timescale|unconnected_drive|undef|undefineall)\\b',
+            end: '$',
+            keywords: {
+              keyword: 'define __FILE__ __LINE__ begin_keywords celldefine default_nettype define else elsif end_keywords endcelldefine endif ifdef ifndef include line nounconnected_drive pragma resetall timescale unconnected_drive undef undefineall'
+            },
+            contains: [
+              hljs.C_LINE_COMMENT_MODE
+            ]
+          },
+          {
+            begin: '`[a-zA-Z_][a-zA-Z0-9_]*\\b',
+            relevance: 0
+          }
+        ]
       }
     ]
   };


### PR DESCRIPTION
This PR fixes the incorrect meta scope handling in Verilog syntax highlighting.

Problem:
- Text from backquotes (`) to end-of-line was incorrectly treated as `meta` scope
- Comments following preprocessor directives were not highlighted properly
- Macro usage highlighting was incorrect

Changes:
1. Modified meta rule implementation to use variants:
   - One variant for preprocessor directives that extend to end-of-line
   - Another variant for macro usage that only applies to the identifier

2. Added proper comment handling within preprocessor directives

Example:
```verilog
`define CONSTANT value // Now comments work correctly
wire result = `CONSTANT + variable; // Proper macro usage highlighting
```

Before this fix, the syntax highlighting treated everything after backticks as meta scope. Now it correctly handles:
- Preprocessor directives
- Comments within directives
- Macro usage in code

Tested with both `highlight` and `highlightAuto` functions.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
