### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3381 -- Fixed incorrect Python keyword highlighting within identifiers

### DIFF
--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -144,7 +144,7 @@ export default function(hljs) {
   ];
 
   const KEYWORDS = {
-    $pattern: /[A-Za-z]\w+|__\w+__/,
+    $pattern: IDENT_RE,
     keyword: RESERVED_WORDS,
     built_in: BUILT_INS,
     literal: LITERALS,


### PR DESCRIPTION
### Issue
HighlightJS was incorrectly highlighting parts of Python identifiers as keywords (e.g. 'def' within '_undef').

### Root Cause
The pattern used for matching keywords (/[A-Za-z]\w+|__\w+__/) did not properly respect identifier boundaries, causing partial matches within larger identifiers.

### Changes Made
- Modified KEYWORDS.$pattern in python.js to use IDENT_RE
- This ensures proper identifier boundary handling
- Prevents keywords from being matched when they appear as part of larger identifiers

### Testing
Verified that identifiers like '_undef' are no longer incorrectly split and highlighted:
```python
foo = _undef  # Now correctly highlighted as a single identifier
```

### Backwards Compatibility
- No breaking changes
- Improves syntax highlighting accuracy
- Restores behavior similar to pre-11.0.0 versions

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
