### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3516 -- CSS: Fixed incorrect string highlighting within parentheses in URLs

### DIFF
--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -83,11 +83,10 @@ export default function(hljs) {
             relevance: 0, // from keywords
             keywords: { built_in: "url data-uri" },
             contains: [
+              ...STRINGS,
               {
                 className: "string",
-                // any character other than `)` as in `url()` will be the start
-                // of a string, which ends with `)` (from the parent mode)
-                begin: /[^)]/,
+                begin: /[^)"'\s][^)]*/, // match unquoted URLs
                 endsWithParent: true,
                 excludeEnd: true
               }


### PR DESCRIPTION
## Issue
CSS URLs containing parentheses within quoted strings were being incorrectly highlighted due to the parser prematurely matching closing parentheses.

## Changes
- Modified the URL pattern matcher in css.js to properly handle quoted strings
- Added STRINGS array to the 'contains' property of URL matcher
- Ensures quoted strings take precedence over unquoted content in URL matching

## Impact
- Correctly highlights URLs containing parentheses when enclosed in quotes
- Maintains proper string boundary detection regardless of parentheses
- Improves CSS syntax highlighting accuracy

## Testing
Verified with the following test cases:
```css
url('/path/with (parentheses)/file.jpg')
url("/path/with (parentheses)/file.jpg")
url(/path/without/quotes.jpg)
```

All cases now highlight correctly, with quoted strings properly maintaining their boundaries.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
