### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3644 -- Added support for multi-line comments in CMake syntax highlighting

### DIFF
--- a/src/languages/cmake.js
+++ b/src/languages/cmake.js
@@ -52,7 +52,21 @@ export default function(hljs) {
         begin: /\$\{/,
         end: /\}/
       },
-      hljs.HASH_COMMENT_MODE,
+      {
+        className: 'comment',
+        variants: [
+          {
+            begin: /#\[\[/,
+            end: /\]\]/,
+            contains: ['self'],
+            relevance: 10
+          },
+          {
+            begin: /#/,
+            end: /$/
+          }
+        ]
+      },
       hljs.QUOTE_STRING_MODE,
       hljs.NUMBER_MODE
     ]


### PR DESCRIPTION
### Problem
CMake's multi-line comments (#[[...]]) were not properly supported and were being treated as single-line comments.

### Changes
- Replaced `hljs.HASH_COMMENT_MODE` with a custom comment mode implementation
- Added support for CMake's multi-line comment syntax (#[[...]])
- Implemented proper nesting support for multi-line comments
- Set higher relevance for multi-line comments to ensure correct precedence

### Implementation Details
- Multi-line comments now correctly match from #[[ to ]]
- Comments can be nested (e.g., #[[ outer #[[ inner ]] outer ]])
- Single-line comments (#) continue to work as expected

### Testing
Verified that the following syntax is now correctly highlighted:
```cmake
#[[test
test
test]]
```

All content between #[[ and ]] is properly recognized as a comment, regardless of line breaks.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
