### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3457 -- Fix for bold + italics combined markdown rendering

### DIFF
--- a/src/languages/markdown.js
+++ b/src/languages/markdown.js
@@ -145,6 +145,16 @@ export default function(hljs) {
     contains: [], // defined later
     variants: [
       {
+        begin: /\*{3}/,
+        end: /\*{3}/,
+        className: 'strong emphasis'
+      },
+      {
+        begin: /_{3}/,
+        end: /_{3}/,
+        className: 'strong emphasis'
+      },
+      {
         begin: /_{2}/,
         end: /_{2}/
       },


### PR DESCRIPTION
## Issue
Markdown text with combined bold and italic formatting (using *** or ___) would cause incorrect rendering, making the rest of the document appear in bold and italics.

## Changes
- Added new variants to the BOLD definition in markdown.js
- Created specific patterns for triple asterisks (***) and triple underscores (___)
- Applied combined 'strong emphasis' className for proper styling
- Prioritized these patterns by placing them at the start of the variants array

## Testing
Before/after screenshots in the ticket show the proper rendering of combined bold and italic formatting.

## Impact
This fix ensures proper rendering of markdown text that uses combined bold and italic formatting without affecting the rest of the document.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
