### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3411 -- Fix inconsistent highlighting of camelCase type parameters in TypeScript

### DIFF
--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -25,6 +25,15 @@ export default function(hljs) {
     "never",
     "enum"
   ];
+  const TYPE_PARAM_LIST = {
+    begin: /</,
+    end: />/,
+    contains: [{
+      className: 'type',
+      begin: IDENT_RE,
+      relevance: 0
+    }]
+  };
   const NAMESPACE = {
     beginKeywords: 'namespace',
     end: /\{/,
@@ -42,7 +51,8 @@ export default function(hljs) {
       built_in: TYPES
     },
     contains: [
-      tsLanguage.exports.CLASS_REFERENCE
+      tsLanguage.exports.CLASS_REFERENCE,
+      TYPE_PARAM_LIST
     ]
   };
   const USE_STRICT = {
@@ -92,6 +102,7 @@ export default function(hljs) {
     DECORATOR,
     NAMESPACE,
     INTERFACE,
+    TYPE_PARAM_LIST
   ]);
 
   // TS gets a simpler shebang rule than JS


### PR DESCRIPTION
### Issue
Type parameters in TypeScript using camelCase (e.g., `OutT`) were being incorrectly tokenized, leading to inconsistent syntax highlighting where only the first part was properly highlighted.

### Changes Made
- Added new `TYPE_PARAM_LIST` rule to TypeScript grammar
- Improved handling of type parameters between angle brackets
- Ensures camelCase identifiers are treated as single tokens

### Technical Details
The fix modifies the TypeScript grammar to properly recognize type parameters as complete identifiers rather than splitting them into parts. This ensures consistent highlighting for:
- Simple type parameters (e.g., `T`, `U`)
- CamelCase type parameters (e.g., `OutT`, `InT`)
- Complex generic type expressions

### Testing
Verified against the original test case:
```typescript
type ParseFunc<OutT, InT> = (val: InT) => OutT;
```
Now shows consistent highlighting matching GitHub's behavior.

### Related Issues
- Fixes [PLAYGROUND-PR-3411]()
- Aligns with GitHub's syntax highlighting behavior

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
