### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2703 -- Fixed incorrect comment highlighting in Scala class definitions and JavaScript parameter lists

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -78,14 +78,12 @@ export default function(hljs) {
     NUMBER,
     hljs.REGEXP_MODE
   ];
-  var PARAMS_CONTAINS = SUBST.contains.concat([
-    // eat recursive parens in sub expressions
-    { begin: /\(/, end: /\)/,
+  var PARAMS_CONTAINS = [hljs.C_LINE_COMMENT_MODE, hljs.C_BLOCK_COMMENT_MODE].concat(
+    SUBST.contains,
+    [{ begin: /\(/, end: /\)/,
       contains: ["self"].concat(SUBST.contains, [hljs.C_BLOCK_COMMENT_MODE, hljs.C_LINE_COMMENT_MODE])
-    },
-    hljs.C_BLOCK_COMMENT_MODE,
-    hljs.C_LINE_COMMENT_MODE
-  ]);
+    }]
+  );
   var PARAMS = {
     className: 'params',
     begin: /\(/, end: /\)/,

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -66,7 +66,7 @@ export default function(hljs) {
   var CLASS = {
     className: 'class',
     beginKeywords: 'class object trait type',
-    end: /[:={\[\n;]/,
+    end: /[:={\[\n;]|\s+\/\//,
     excludeEnd: true,
     contains: [
       {


### PR DESCRIPTION
This PR fixes two syntax highlighting issues:

1. Scala Class Comments Fix
- Fixed incorrect highlighting of end-of-line comments after class declarations
- Comments are now properly rendered instead of being treated as class titles
- Modified CLASS definition's end pattern to properly handle whitespace followed by comments

Before:
```scala
class A  // Something goes here  <- Comment was highlighted as class title
```

After:
```scala
class A  // Something goes here  <- Comment is properly highlighted
```

2. JavaScript Parameter Comments Fix
- Fixed comments not being highlighted within parameter lists
- Improved comment detection by giving them higher precedence in PARAMS_CONTAINS array
- Comments now render correctly regardless of their position in parameter lists

Before:
```javascript
function(a,  // first param  <- Comment was not highlighted
         b)   // second param
```

After:
```javascript
function(a,  // first param  <- Comment is properly highlighted
         b)   // second param
```

Tested with various code samples to ensure both fixes work as intended and don't introduce regressions.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
