### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-2785 -- Added variable highlighting for PHP variables

### DIFF
--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -12,6 +12,7 @@ Category: common
  * */
 export default function(hljs) {
   var VARIABLE = {
+    className: 'variable',
     begin: '\\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*'
   };
   var PREPROCESSOR = {


### PR DESCRIPTION
This PR adds proper syntax highlighting for PHP variables by configuring the className property.

Changes:
- Added className: 'variable' to the VARIABLE token definition in src/languages/php.js
- Variables like $response will now be distinctly highlighted
- Maintains existing regex pattern for PHP variable identification

Before this change, PHP variables were not highlighted, making code snippets harder to read. After this change, variables are properly highlighted as shown in the ticket's example screenshot.

Tested:
- Verified variable highlighting works correctly for basic PHP variables
- Confirmed no impact on other PHP syntax highlighting features

Resolves issue [PLAYGROUND-PR-2785]()

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
