### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3000 -- Fix highlighting of PHP arrow functions

### DIFF
--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -74,7 +74,7 @@ export default function(hljs) {
     // Other keywords:
     // <https://www.php.net/manual/en/reserved.php>
     // <https://www.php.net/manual/en/language.types.type-juggling.php>
-    'array abstract and as binary bool boolean break callable case catch class clone const continue declare ' +
+    'array abstract and as binary bool boolean break callable case catch class clone const continue declare fn ' +
     'default do double else elseif empty enddeclare endfor endforeach endif endswitch endwhile eval extends ' +
     'final finally float for foreach from global goto if implements instanceof insteadof int integer interface ' +
     'isset iterable list match|0 new object or private protected public real return string switch throw trait ' +
@@ -131,7 +131,7 @@ export default function(hljs) {
       {
         className: 'function',
         relevance: 0,
-        beginKeywords: 'fn function', end: /[;{]/, excludeEnd: true,
+        beginKeywords: 'function', end: /[;{]/, excludeEnd: true,
         illegal: '[$%\\[]',
         contains: [
           hljs.UNDERSCORE_TITLE_MODE,


### PR DESCRIPTION
This PR fixes the incorrect syntax highlighting of PHP arrow functions that use the 'fn' keyword.

Problem:
- Arrow functions using 'fn' were being incorrectly treated as regular function declarations
- This caused comments in arrow functions to be highlighted as function titles

Changes:
- Added 'fn' to the PHP keywords list
- Removed 'fn' from function detection keywords

Example of fixed highlighting:
```php
$fn1 = fn($x) => $x + $y;
```

The arrow function is now correctly highlighted with:
- 'fn' as a keyword
- Parameters and variables properly recognized
- No incorrect title detection

This change improves the syntax highlighting accuracy for modern PHP code that uses arrow functions.

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
