### PR TITLE
[morph.ai] Fixed PLAYGROUND-PR-3301 -- Fixed inline CSS comments not highlighting correctly in property values

### DIFF
--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -86,6 +86,7 @@ export default function(hljs) {
           modes.IMPORTANT,
           modes.CSS_NUMBER_MODE,
           ...STRINGS,
+          hljs.C_BLOCK_COMMENT_MODE,
           // needed to highlight these as strings and to avoid issues with
           // illegal characters that might be inside urls that would tigger the
           // languages illegal stack


### PR DESCRIPTION
This PR fixes a regression in CSS inline comment highlighting that was introduced in version 10.6.0.

Changes:
- Added hljs.C_BLOCK_COMMENT_MODE to the contains array in the attribute value section
- Positioned it between STRINGS spread and url/data-uri block

Before:
- Inline CSS comments within property values were not being highlighted
- This affected code using the new `highlightAll` API introduced in 10.6.0

After:
- CSS comments are now properly highlighted within property values
- Restores the expected behavior that was present in version 10.5.0

Testing:
- Verified using the provided test cases in the issue
- Confirms proper highlighting of inline comments in CSS property values

[Additional ticket processing details](https://app.morph.ai/app/tickets/99999)
